### PR TITLE
List fundable MFA improvements

### DIFF
--- a/FUNDABLES.md
+++ b/FUNDABLES.md
@@ -302,6 +302,16 @@ We are interested in developing a shared interface and implementation for variou
 
 ## Security improvements and prerequisites
 
+### Improved support for Multi-Factor Authentication in Warehouse (PyPI)
+
+To mitigate account takeover attacks, where attackers upload malicious code in existing popular packages, we need to continue improving our support for MFA and use of API tokens instead of password-based auth.  This work would involve research, development, and technical writing to finalise and implement existing proposals including:
+
+- [Require API Tokens for upload if MFA is enabled](https://github.com/pypa/warehouse/issues/7265) (upload currently bypasses MFA)
+- [Add ability to require MFA for a given project](https://github.com/pypa/warehouse/issues/5792)
+- [other issues tagged `tokens`](https://github.com/pypa/warehouse/labels/tokens)
+
+Once these technical prerequisites are satisfied, we would be able to [revisit discussion of MFA *policy*](https://discuss.python.org/t/require-mfa-on-pypi/12077) - including encouraging MFA requirements for popular packages, or even mandating it for all users as some other package registries are considering.  This subsequent work would involve additional development, project management, and community engagement as we determine and implement authentication policy.
+
 ### System to label projects on PyPI with administrative statuses/attributes
 
 To scale up our anti-abuse moderation and help package maintainers with


### PR DESCRIPTION
As suggested by @pradyunsg in https://discuss.python.org/t/require-mfa-on-pypi/12077/22

I think it's fairly likely that concrete work on MFA support could be funded by corporate users based on their direct interest in mitigating account takeover threats, possibly through organisations such as [the OpenSSF](https://openssf.org/).