### PR TITLE
Add more historical context to lock files

### DIFF
--- a/FUNDABLES.md
+++ b/FUNDABLES.md
@@ -213,8 +213,12 @@ some progress toward standardizing an interoperable lockfile
 format](https://github.com/uranusjr/lock-file), but we need to finish [that
 design standardization and consensus-gathering
 work](https://discuss.python.org/t/structured-exchangeable-lock-file-format-requirements-txt-2-0/876/)
-and implement it in `pip`, `pipenv`, and related tools. We'd need Python
+and implement it in `pip`, `pipenv`, and related tools. Other attempts reached the PEP
+stage [^pep-650][^pep-665], but ultimately were rejected. We'd need Python
 engineering work and project management to develop and deploy this.
+
+[^pep-650]: https://peps.python.org/pep-0650/
+[^pep-665]: https://peps.python.org/pep-0665/
 
 ### Package preview feature for PyPI
 


### PR DESCRIPTION
<!--

Thanks for suggesting a fundable task!

Please check that your suggestion is:

 1. something the Python packaging community wants:
    - there's already consensus among project maintainers
    - if a PEP is involved, it's been accepted.

 2. fairly well-scoped

 3. fundable: would happen much faster if the Packaging Working Group got
    funding to implement the work, through donations or grants/directed gifts.

-->

**What is the current situation/context?**
<!-- Example: "Scientists need to install some Python packages via pip and others with conda." -->

**What ought to be fixed, made, or implemented?**
<!-- Please link to an issue on GitHub, GitLab, Bitbucket, or similar. -->

**What problems would this solve, and what new capabilities would it cause?**
<!-- Please link to specific issues, mailing list posts, blogs, etc. -->

**What kinds of work are necessary to make this happen?**
<!-- For example: backend development, frontend development, testing, systems administration, project management, user experience research and design, marketing, technical writing, and hardware research. -->
