### PR TITLE
Add support for reproducible builds to setuptools/wheel

### DIFF
--- a/FUNDABLES.md
+++ b/FUNDABLES.md
@@ -166,6 +166,29 @@ We need funding for several weeks of technical writer work and developer review 
 * de-duplicate the distutils and setuptools documentation, making the latter independent of the former
 * re-organize the setuptools documentation
 
+### Add support for reproducible builds to setuptools
+
+[Reproducible builds](https://en.wikipedia.org/wiki/Reproducible_builds) allow
+developers to independently verify that a distributed software package was not
+tampered with. Since a considerable number of the Python packages use
+`setuptools`, adding support for reproducible builds to this build backend
+can help to improve security in Python ecosystem as a whole.
+Some preliminary works that can help structuring this activity are available (see
+[pypa/setuptools#2133](https://github.com/pypa/setuptools/issues/2133),
+[pypa/setuptools#1512](https://github.com/pypa/setuptools/pull/1512) and
+[pypa/wheel#362](https://github.com/pypa/wheel/issues/362)), however the
+effort was never concluded. Funding would be used finalize the development of
+this feature.
+
+Import tasks are:
+- Support `SOURCE_DATA_EPOCH` environment variable for both sdists and wheels.
+- Make both sdist and wheels independent of umask.
+- Ensure that C/C++-extensions compiled with setuptools are reproducible.
+- Document the process of verifying a sdist or wheel.
+
+This project might require coordination with other tools in the ecosystem
+(e.g. `wheel`).
+
 ### Audit and update package metadata
 
 If we [audit and update PyPI metadata for existing projects based on


### PR DESCRIPTION
This proposal was motivated by the [recent discourse thread](https://discuss.python.org/t/updating-fundable-packaging-projects/16566/4)

<!--

Thanks for suggesting a fundable task!

Please check that your suggestion is:

 1. something the Python packaging community wants:
    - there's already consensus among project maintainers
    - if a PEP is involved, it's been accepted.

 2. fairly well-scoped

 3. fundable: would happen much faster if the Packaging Working Group got
    funding to implement the work, through donations or grants/directed gifts.

-->

**What is the current situation/context?**

Currently the combination of setuptools/wheel does not support
reproducible builds completely. This makes some kinds of build non-verifiable.

**What ought to be fixed, made, or implemented?**

Complete support for reproducible build for both sdist and wheel using
setuptools as a build backend.


**What problems would this solve, and what new capabilities would it cause?**
<!-- Please link to specific issues, mailing list posts, blogs, etc. -->

This would help to improve security in the Python packaging ecosystem,
because developers would be able to independently verify packages.

**What kinds of work are necessary to make this happen?**
<!-- For example: backend development, frontend development, testing, systems administration, project management, user experience research and design, marketing, technical writing, and hardware research. -->

Implementation efforts are required for:

- Support `SOURCE_DATA_EPOCH` environment variable for both sdists and wheels.
- Make both sdist and wheels independent of umask.
- Ensure that C/C++-extensions compiled with setuptools are reproducible.

Documentation efforts are required to instruct developers how to verify
distribution artifacts.